### PR TITLE
Browsers like safari do't throw the error obj for un-supported browser errors. 

### DIFF
--- a/panic-overlay.js
+++ b/panic-overlay.js
@@ -403,7 +403,13 @@ function toggle (yes) {
 
 function onUncaughtError (e) { if (config.handleErrors) panic (e) }
 
-window.addEventListener ('error',              e => onUncaughtError (e.error))
+window.addEventListener ('error', e => {
+    if (!e.error) {
+        onUncaughtError (e.message)
+        return
+    }
+    onUncaughtError (e.error)
+})
 window.addEventListener ('unhandledrejection', e => onUncaughtError (e.reason))
 
 ;(function onReady (fn) {


### PR DESCRIPTION
``
SyntaxError: Invalid regular expression: invalid group specifier name
``


<img width="882" alt="Screenshot 2022-06-23 at 3 07 38 PM" src="https://user-images.githubusercontent.com/11075561/175268726-779a9227-bc1c-48e8-a664-071e8cb770c8.png">
